### PR TITLE
ci: add cross-platform Tauri build workflow (#62)

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -73,7 +73,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   tagName: v__VERSION__
-                  releaseName: "AutoTrixel v__VERSION__"
+                  releaseName: "TrKixel v__VERSION__"
                   releaseBody: "See the assets for download links."
                   releaseDraft: true
                   prerelease: false

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -1,0 +1,80 @@
+name: Tauri Cross-Platform Build
+
+on:
+    push:
+        branches:
+            - main
+            - release
+    workflow_dispatch:
+
+jobs:
+    build-tauri:
+        permissions:
+            contents: write
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - platform: ubuntu-latest
+                      args: ""
+                    - platform: macos-latest
+                      args: ""
+                    - platform: windows-latest
+                      args: ""
+
+        runs-on: ${{ matrix.platform }}
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v6
+
+            - name: Install system dependencies (Ubuntu)
+              if: matrix.platform == 'ubuntu-latest'
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v5
+              with:
+                  node-version: "20"
+                  cache: "npm"
+
+            - name: Setup Rust
+              uses: dtolnay/rust-toolchain@stable
+
+            - name: Cache Cargo registry
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      ~/.cargo/bin/
+                      ~/.cargo/registry/index/
+                      ~/.cargo/registry/cache/
+                      ~/.cargo/git/db/
+                  key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-cargo-registry-
+
+            - name: Cache Cargo build target
+              uses: actions/cache@v4
+              with:
+                  path: src-tauri/target
+                  key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('src-tauri/src/**') }}
+                  restore-keys: |
+                      ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}-
+                      ${{ runner.os }}-cargo-target-
+
+            - name: Install JS dependencies
+              run: npm ci
+
+            - name: Build Tauri app
+              uses: tauri-apps/tauri-action@v0
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  tagName: v__VERSION__
+                  releaseName: "AutoTrixel v__VERSION__"
+                  releaseBody: "See the assets for download links."
+                  releaseDraft: true
+                  prerelease: false
+                  args: ${{ matrix.args }}

--- a/.github/workflows/tauri-check.yml
+++ b/.github/workflows/tauri-check.yml
@@ -1,0 +1,61 @@
+name: Tauri PR Check
+
+on:
+    pull_request:
+        branches:
+            - main
+            - release
+            - "epic/**"
+
+jobs:
+    check:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v6
+
+            - name: Install system dependencies
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v5
+              with:
+                  node-version: "20"
+                  cache: "npm"
+
+            - name: Setup Rust
+              uses: dtolnay/rust-toolchain@stable
+
+            - name: Cache Cargo registry
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      ~/.cargo/bin/
+                      ~/.cargo/registry/index/
+                      ~/.cargo/registry/cache/
+                      ~/.cargo/git/db/
+                  key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-cargo-registry-
+
+            - name: Cache Cargo build target
+              uses: actions/cache@v4
+              with:
+                  path: src-tauri/target
+                  key: ${{ runner.os }}-cargo-target-check-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('src-tauri/src/**') }}
+                  restore-keys: |
+                      ${{ runner.os }}-cargo-target-check-${{ hashFiles('**/Cargo.lock') }}-
+                      ${{ runner.os }}-cargo-target-
+
+            - name: Install JS dependencies
+              run: npm ci
+
+            - name: Check frontend build
+              run: npm run build
+
+            - name: Check Rust compilation
+              working-directory: src-tauri
+              run: cargo check


### PR DESCRIPTION
## Summary

- Adds `tauri-build.yml`: matrix build across Ubuntu, macOS, and Windows using the official `tauri-apps/tauri-action@v0`. Triggers on push to `main`/`release` or manual dispatch. Creates draft GitHub Releases so builds can be reviewed before publishing.
- Adds `tauri-check.yml`: fast PR gate that runs `cargo check` in `src-tauri/` and `npm run build` on Linux only, catching compilation errors cheaply before the full matrix build.
- Both workflows cache Cargo registry and `src-tauri/target` to keep Rust build times manageable.

## Test plan

- [ ] Verify `tauri-build.yml` triggers on push to `main` and produces draft releases with platform artifacts
- [ ] Verify `tauri-check.yml` triggers on PRs targeting `main`, `release`, and `epic/**` branches
- [ ] Confirm existing `deploy-to-pages.yml` and `version-bump.yml` are unmodified
- [ ] Confirm Cargo caches hit on subsequent runs (check cache key in Actions UI)
- [ ] Confirm draft release is created (not published) after a successful build

🤖 Generated with [Claude Code](https://claude.com/claude-code)