### PR TITLE
feat(cli): wire browser export to headless core (#42)

### DIFF
--- a/src/core/export.js
+++ b/src/core/export.js
@@ -127,12 +127,13 @@ export function renderPNG(engine, adapter) {
 
 /**
  * Render grid data to an SVG string using the headless engine.
- * Note: grid-line overlay is not supported in headless mode — the browser
- * export's grid-line toggle (exportGridToggle) has no headless equivalent.
- * For full SVG feature parity including grid lines, use exportSVGAsString
- * via createTrKixel (src/logic/autotrixel/export.js).
+ * @param {object} engine - The headless engine instance.
+ * @param {object} [gridOptions] - Optional grid overlay settings.
+ * @param {boolean} [gridOptions.includeGrid=false] - When true, appends grid-line SVG elements
+ *   (horizontal lines and triangle edge polylines). Capped at 400 000 triangles to avoid
+ *   generating excessively large SVG output.
  */
-export function renderSVG(engine) {
+export function renderSVG(engine, gridOptions = {}) {
     const config = engine.getConfig();
     const gridData = engine.getGridData();
     const { triHeight, W_half } = engine.getDerived();
@@ -189,6 +190,31 @@ export function renderSVG(engine) {
             svg += generateRecursiveSvg(vertices[0], vertices[1], vertices[2], colorOrData);
         }
     });
+
+    if (gridOptions.includeGrid && config.widthTriangles * config.heightTriangles <= 400_000) {
+        const gridColor = config.gridColor;
+
+        for (let r = 0; r <= config.heightTriangles; r++) {
+            const y = r * triHeight;
+            svg += `<line x1="0" y1="${y}" x2="${w}" y2="${y}" stroke="${gridColor}" stroke-width="0.5"/>`;
+        }
+
+        for (let r = 0; r < config.heightTriangles; r++) {
+            for (let c = 0; c < config.widthTriangles; c++) {
+                const xBase = c * W_half;
+                const yBase = r * triHeight;
+                const isUp = r % 2 === Math.abs(c) % 2;
+
+                let p = "";
+                if (isUp) {
+                    p = `${xBase},${yBase + triHeight} ${xBase + W_half},${yBase} ${xBase + 2 * W_half},${yBase + triHeight}`;
+                } else {
+                    p = `${xBase},${yBase} ${xBase + W_half},${yBase + triHeight} ${xBase + 2 * W_half},${yBase}`;
+                }
+                svg += `<polyline points="${p}" fill="none" stroke="${gridColor}" stroke-width="0.5"/>`;
+            }
+        }
+    }
 
     svg += "</svg>";
     return svg;

--- a/src/logic/createTrKixel.js
+++ b/src/logic/createTrKixel.js
@@ -1,8 +1,9 @@
 import { REQUIRED_SELECTORS } from "./autotrixel/constants.js";
 import { clamp, hexToOklchVals } from "./autotrixel/utils.js";
 import { getTriangleVertices, getBarycentric } from "./autotrixel/geometry.js";
-import { fullRedraw, drawCursor } from "./autotrixel/drawing.js";
-import { exportImage, exportSVG, exportImageAsBlob, exportSVGAsString } from "./autotrixel/export.js";
+import { fullRedraw, drawCursor, drawGridLines } from "./autotrixel/drawing.js";
+import { renderSVG, renderToCanvas } from "../core/export.js";
+import { createBrowserCanvasAdapter } from "../core/adapters/browser.js";
 import { createEngine } from "../core/engine.js";
 
 export function createTrKixel(rootElement) {
@@ -71,6 +72,7 @@ export function createTrKixel(rootElement) {
     // --- Core engine ---
 
     const engine = createEngine();
+    const browserAdapter = createBrowserCanvasAdapter();
 
     // --- Browser-only state ---
 
@@ -150,6 +152,15 @@ export function createTrKixel(rootElement) {
             clearTimeout(toastTimeout);
         }
         toastTimeout = window.setTimeout(() => toast.classList.remove("show"), 1500);
+    }
+
+    function triggerDownload(blob, filename) {
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.download = filename;
+        link.href = url;
+        link.click();
+        setTimeout(() => URL.revokeObjectURL(url), 100);
     }
 
     function updateUndoButton() {
@@ -951,12 +962,22 @@ export function createTrKixel(rootElement) {
         exportImage: () => {
             const config = engine.getConfig();
             const { triHeight, W_half } = engine.getDerived();
-            exportImage(artCanvas, engine.getGridData(), config, triHeight, W_half, exportGridToggle, showToast, engine.getImageRegistry());
+            const canvas = renderToCanvas(engine, browserAdapter);
+            if (exportGridToggle.checked) {
+                const ctx = canvas.getContext("2d");
+                drawGridLines(ctx, canvas, config, triHeight, W_half);
+            }
+            canvas.toBlob((blob) => {
+                if (!blob) return;
+                triggerDownload(blob, "tripixel-art.png");
+                showToast("Image Saved!");
+            }, "image/png");
         },
         exportSVG: () => {
-            const config = engine.getConfig();
-            const { triHeight, W_half } = engine.getDerived();
-            exportSVG(artCanvas, engine.getGridData(), config, triHeight, W_half, exportGridToggle, showToast);
+            const svg = renderSVG(engine, { includeGrid: exportGridToggle.checked });
+            const blob = new Blob([svg], { type: "image/svg+xml" });
+            triggerDownload(blob, "tripixel-art.svg");
+            showToast("SVG Saved!");
         },
         destroy: () => {
             windowListeners.forEach((dispose) => dispose());
@@ -990,14 +1011,11 @@ export function createTrKixel(rootElement) {
             redraw();
         },
         exportImageAsBlob: () => {
-            const config = engine.getConfig();
-            const { triHeight, W_half } = engine.getDerived();
-            return exportImageAsBlob(artCanvas, engine.getGridData(), config, triHeight, W_half, engine.getImageRegistry());
+            const canvas = renderToCanvas(engine, browserAdapter);
+            return browserAdapter.canvasToBlob(canvas);
         },
         exportSVGAsString: () => {
-            const config = engine.getConfig();
-            const { triHeight, W_half } = engine.getDerived();
-            return exportSVGAsString(artCanvas, engine.getGridData(), config, triHeight, W_half);
+            return renderSVG(engine);
         },
         setTool,
         undoAction,


### PR DESCRIPTION
## Summary
- `createTrKixel` now delegates all four export paths (`exportImage`, `exportSVG`, `exportImageAsBlob`, `exportSVGAsString`) to the shared headless core in `src/core/export.js`, removing direct imports from `src/logic/autotrixel/export.js`
- `renderSVG` gains an optional `gridOptions.includeGrid` param for SVG grid-line overlay, capped at 400 000 triangles to prevent runaway output
- Introduces `triggerDownload` helper to consolidate blob → `<a>` download logic (was duplicated across PNG and SVG paths)
- `createBrowserCanvasAdapter` is wired in at engine init, completing the browser adapter integration

## Test plan
- [ ] Export PNG with and without grid overlay — verify download and visual correctness
- [ ] Export SVG with and without grid overlay — open in browser/Inkscape, verify polylines render correctly
- [ ] Export PNG from browser (`exportImageAsBlob`) — verify blob is valid
- [ ] Export SVG as string (`exportSVGAsString`) — verify no grid lines included by default
- [ ] Large grid (>400 000 triangles) SVG export with grid toggle on — verify grid overlay is silently skipped, no crash
- [ ] Undo/redo after export — verify no state corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)