### PR TITLE
fix(ci): reset major bump + repair vbump YAML and release staleness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,30 +19,6 @@ jobs:
                   ref: release
                   fetch-depth: 0
 
-            - name: Read version
-              id: get_version
-              run: |
-                  if [ ! -f VERSION ]; then
-                    echo "Error: No VERSION file found"
-                    exit 1
-                  fi
-
-                  VERSION=$(cat VERSION | tr -d '[:space:]')
-                  echo "version=$VERSION" >> $GITHUB_OUTPUT
-                  echo "Creating release for version: $VERSION"
-
-                  # Parse version components
-                  if [[ $VERSION =~ ^([0-9]{2})\.([0-9]+)\.([0-9]+)\.([0-9]+)([a-zA-Z]*)$ ]]; then
-                    YY="${BASH_REMATCH[1]}"
-                    MAJOR="${BASH_REMATCH[2]}"
-                    MINOR="${BASH_REMATCH[3]}"
-                    PATCH="${BASH_REMATCH[4]}"
-                    echo "year=20$YY" >> $GITHUB_OUTPUT
-                    echo "major=$MAJOR" >> $GITHUB_OUTPUT
-                    echo "minor=$MINOR" >> $GITHUB_OUTPUT
-                    echo "patch=$PATCH" >> $GITHUB_OUTPUT
-                  fi
-
             - name: Sync VERSION from main
               run: |
                   git fetch origin main
@@ -74,8 +50,30 @@ jobs:
                       git commit -m "ci: sync version $MAIN_VERSION from main [skip ci]"
                       git push origin release
                     }
+                  fi
 
-                    echo "version=$MAIN_VERSION" >> $GITHUB_OUTPUT
+            - name: Read version
+              id: get_version
+              run: |
+                  if [ ! -f VERSION ]; then
+                    echo "Error: No VERSION file found"
+                    exit 1
+                  fi
+
+                  VERSION=$(cat VERSION | tr -d '[:space:]')
+                  echo "version=$VERSION" >> $GITHUB_OUTPUT
+                  echo "Creating release for version: $VERSION"
+
+                  # Parse version components
+                  if [[ $VERSION =~ ^([0-9]{2})\.([0-9]+)\.([0-9]+)\.([0-9]+)([a-zA-Z]*)$ ]]; then
+                    YY="${BASH_REMATCH[1]}"
+                    MAJOR="${BASH_REMATCH[2]}"
+                    MINOR="${BASH_REMATCH[3]}"
+                    PATCH="${BASH_REMATCH[4]}"
+                    echo "year=20$YY" >> $GITHUB_OUTPUT
+                    echo "major=$MAJOR" >> $GITHUB_OUTPUT
+                    echo "minor=$MINOR" >> $GITHUB_OUTPUT
+                    echo "patch=$PATCH" >> $GITHUB_OUTPUT
                   fi
 
             - name: Create git tag

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -87,7 +87,11 @@ jobs:
                   else
                     case "$BUMP_TYPE" in
                       major)
+                        # Reset MINOR and PATCH on a major bump. Forks: do NOT
+                        # carry these over — 26.3.2.1 must become 26.4.0.0, not 26.4.2.1.
                         MAJOR=$((MAJOR + 1))
+                        MINOR=0
+                        PATCH=0
                         SUFFIX=""
                         NEW_VERSION="$YY.$MAJOR.$MINOR.$PATCH"
                         ;;
@@ -108,19 +112,19 @@ jobs:
                         else
                           # Increment suffix as base-26: a..z, aa..az, ba..zz, aaa...
                           SUFFIX=$(python3 -c "
-def inc(s):
-    chars = list(s)
-    i = len(chars) - 1
-    while i >= 0:
-        if chars[i] == 'z':
-            chars[i] = 'a'
-            i -= 1
-        else:
-            chars[i] = chr(ord(chars[i]) + 1)
-            return ''.join(chars)
-    return 'a' + ''.join(chars)
-print(inc('$SUFFIX'))
-")
+                  def inc(s):
+                      chars = list(s)
+                      i = len(chars) - 1
+                      while i >= 0:
+                          if chars[i] == 'z':
+                              chars[i] = 'a'
+                              i -= 1
+                          else:
+                              chars[i] = chr(ord(chars[i]) + 1)
+                              return ''.join(chars)
+                      return 'a' + ''.join(chars)
+                  print(inc('$SUFFIX'))
+                  ")
                         fi
                         NEW_VERSION="$YY.$MAJOR.$MINOR.$PATCH$SUFFIX"
                         ;;


### PR DESCRIPTION
Standardizes the version-bump and release CI workflows against the canonical template-repo references.

## Fixes

**(A) major-reset** — `version-bump.yml` `major)` case now sets `MINOR=0` and `PATCH=0` after `MAJOR=$((MAJOR + 1))`. Previously a major bump on `26.3.2.1` produced `26.4.2.1`; it now correctly produces `26.4.0.0`.

**(B) vbump-YAML** — the python3 base-26 suffix-increment heredoc was dedented to column 0, falling out of its `run: |` block and breaking the file (`yaml.safe_load` errored at the heredoc, `mapping values are not allowed here`). Re-indented the heredoc to match the surrounding run block so it renders at column 0 after YAML block-strip. The file now parses and the base-26 increment logic executes (`inc('az') -> 'ba'`).

**(C) release-stale** — in `release.yml`, "Read version" (`id: get_version`) ran BEFORE "Sync VERSION from main", and the GitHub Release step consumes `steps.get_version.outputs.*` — so it published the stale pre-sync version. Reordered so Sync runs first, then Read version captures the synced value. Removed the orphaned `version` output the sync step previously wrote (now redundant).

## Validation
- `python3 -c 'import yaml; yaml.safe_load(...)'` — both files VALID
- `actionlint -shellcheck=` — no schema/parse errors (only pre-existing `github.head_ref` advisories)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)